### PR TITLE
build: bump to Python 3.12 / astropy 7.x baseline (2.1.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,19 +13,20 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.12']
 
     steps:
     - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Cache pip dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
@@ -69,10 +70,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - name: Install dependencies
       run: |
@@ -92,10 +93,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - name: Install build dependencies
       run: |
@@ -122,10 +123,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.12']
 
     steps:
     - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -39,10 +40,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - name: Install build dependencies
       run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Ethoscopy is a Python data analysis toolbox for behavioral time series data from
 ## Development Environment
 
 ### Python Environment
-- **Use Python 3.10+** (project requires >=3.10,<4.0)
+- **Use Python 3.12+** (project requires >=3.12,<4.0)
 - **Always use virtual environment** (`.venv` as mentioned in user's global instructions)
 - **Install in development mode**: `pip install -e .`
 
@@ -21,7 +21,7 @@ Ethoscopy is a Python data analysis toolbox for behavioral time series data from
 ### Key Dependencies
 - Core: pandas >=2.2.2, numpy >=2.0.0
 - Visualization: plotly >=5.22.0, seaborn >=0.13.2
-- Analysis: hmmlearn >=0.3.2, astropy >=6.1, pywavelets >=1.6.0
+- Analysis: hmmlearn >=0.3.2, astropy >=7.0, pywavelets >=1.6.0
 - Dev: ipykernel for Jupyter notebook support
 
 ## Build and Development Commands

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI/CD Pipeline](https://github.com/gilestrolab/ethoscopy/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/gilestrolab/ethoscopy/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/gilestrolab/ethoscopy/branch/main/graph/badge.svg)](https://codecov.io/gh/gilestrolab/ethoscopy)
 [![PyPI version](https://img.shields.io/pypi/v/ethoscopy.svg)](https://pypi.org/project/ethoscopy/)
-[![Python versions](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue.svg)](https://pypi.org/project/ethoscopy/)
+[![Python versions](https://img.shields.io/badge/python-3.12-blue.svg)](https://pypi.org/project/ethoscopy/)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
 A data-analysis toolbox utilising Pandas, Seaborn, and Plotly to curate, clean, analyse, and visualise behavioural time series data. Whilst the toolbix was created around the data produced from an Ethoscope (a Drosophila monitoring system), if the users data follows the same structure for time series data all methods can be utilised.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ethoscopy"
-version = "2.0.5"
+version = "2.1.0"
 description = "\"A python based toolkit to download and anlyse data from the Ethoscope hardware system.\""
 authors = [{name = "Lblackhurst29",email = "lblackhurst29@gmail.com"}]
 readme = "README.md"
@@ -13,18 +13,16 @@ dependencies = [
     "colour>=0.1.5,<0.2.0",
     "hmmlearn>=0.3.2,<0.4.0",
     "pywavelets>=1.6.0,<2.0.0",
-    "astropy>=6.1,<7.0",
+    "astropy>=7.0,<8.0",
     "nbformat>=5.10.4,<6.0.0",
 ]
-requires-python = ">=3.10,<4.0"
+requires-python = ">=3.12,<4.0"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Topic :: Scientific/Engineering :: Information Analysis",


### PR DESCRIPTION
## Summary
- Scheduled CI run [24823915635](https://github.com/gilestrolab/ethoscopy/actions/runs/24823915635) failed across the 3.10/3.11/3.12 matrix at `import ethoscopy` time: astropy 6.1.x eagerly references `np.in1d`, which was removed in numpy 2.0.
- Root cause is dep-pin drift, not our code. Rather than lazy-import astropy as a workaround, lift the Python floor to 3.12 so astropy can move to 7.x where numpy 2.0 is supported cleanly. The shipped Docker image runs Python 3.12.3, so this matches deployment.
- Opportunistic CI hygiene bundled in the same PR: `fail-fast: false`, `setup-python@v4 → @v5`, `cache@v3 → @v4` (Node 20 deprecation).

## Changes
- `pyproject.toml`: `astropy>=7.0,<8.0`; `requires-python>=3.12,<4.0`; drop 3.10/3.11 classifiers; **2.0.5 → 2.1.0** (minor bump — dropping Python versions is breaking for PyPI consumers).
- `.github/workflows/ci.yml`, `.github/workflows/release.yml`: matrix trimmed to `['3.12']`, `fail-fast: false`, action version bumps.
- `README.md` badge, `CLAUDE.md` notes: version markers updated to match.

No source code changes — `periodogram_functions.py` and `behavpy_core.py` are deliberately untouched. The b4f8c7c periodogram fix stays as-is; astropy 7.x just works with numpy 2.x so the eager import chain no longer explodes.

## Test plan
Verified locally against Python 3.14 / astropy 7.2.0 / numpy 2.4.4:
- [x] `python -c "import ethoscopy"` — was crashing, now succeeds
- [x] `pytest tests/ -m "unit"` — 187 passed
- [x] `pytest tests/ -m "integration"` — 13 passed
- [x] `ruff check src/` — clean
- [x] `black --check src/ tests/` — clean
- [x] `python -m build` + `twine check` — PASSED
- [ ] CI run on this PR goes green on 3.12

## Follow-up (separate PR)
- `behavpy_core.py:2670,2674` still uses `eval(per)` to dispatch by periodogram name. Works fine after this fix, but replacing with an explicit dispatch dict would remove a latent footgun.
- After merge: tag `v2.1.0` to trigger the PyPI release pipeline (`release.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)