### PR TITLE
build(docker): pin ethoscopy==2.1.0 in jupyterhub image

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -89,7 +89,7 @@ RUN pip3 install \
         lifelines \
         opencv-python \
         mysql-connector \
-        ethoscopy
+        ethoscopy==2.1.0
        # pycatch22
 
 # Pre-populate tutorial datasets inside the installed package so non-root


### PR DESCRIPTION
## Summary
Pin the `ethoscopy` install in `Docker/Dockerfile` to `==2.1.0`. Previously unpinned, so `--no-cache` rebuilds silently drift to whatever PyPI serves — fine for the ethoscope-lab `1.2` tag today, but a latent source of irreproducibility.

2.1.0 is the first release with the Python 3.12 / astropy 7.x baseline (#8). The image was rebuilt locally with this pin and verified: ethoscopy 2.1.0 / astropy 7.2.0 / numpy 2.4.4 inside the container.

## Test plan
- [x] `docker compose build --no-cache ethoscope-lab` — succeeds
- [x] `docker run --rm --entrypoint python3 ggilestro/ethoscope-lab:1.2 -c "import ethoscopy, astropy, numpy; ..."` — all three versions correct
- [ ] `docker push ggilestro/ethoscope-lab:1.2` — handled by maintainer after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)